### PR TITLE
Allow local volume directory in Moat upgrade scripts

### DIFF
--- a/scripts/deterministic/shell/deploy-dogeos-messenger-impl.sh
+++ b/scripts/deterministic/shell/deploy-dogeos-messenger-impl.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 export FOUNDRY_EVM_VERSION="cancun"

--- a/scripts/deterministic/shell/deploy-fee-vault-moat-adapter.sh
+++ b/scripts/deterministic/shell/deploy-fee-vault-moat-adapter.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 export FOUNDRY_EVM_VERSION="cancun"

--- a/scripts/deterministic/shell/deploy-moat-impl.sh
+++ b/scripts/deterministic/shell/deploy-moat-impl.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 export FOUNDRY_EVM_VERSION="cancun"

--- a/scripts/deterministic/shell/submit-dogeos-messenger-proxy-upgrade.sh
+++ b/scripts/deterministic/shell/submit-dogeos-messenger-proxy-upgrade.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 # Submits ProxyAdmin.upgrade(messengerProxy, newImpl) from the ProxyAdmin owner.

--- a/scripts/deterministic/shell/submit-fee-vault-rewire.sh
+++ b/scripts/deterministic/shell/submit-fee-vault-rewire.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 # Rewires the fee vault through the FeeVaultMoatAdapter (and thus the Moat), in

--- a/scripts/deterministic/shell/submit-moat-proxy-upgrade.sh
+++ b/scripts/deterministic/shell/submit-moat-proxy-upgrade.sh
@@ -10,12 +10,8 @@ fi
 VOLUME_PATH="$REPO_ROOT/volume"
 if [ ! -e "$VOLUME_PATH" ]; then
     echo "missing volume path: $VOLUME_PATH"
-    echo "hint: ln -sfn ../dogeos-aws-devnet $VOLUME_PATH"
+    echo "hint: create $VOLUME_PATH with config.toml and config-contracts.toml"
     exit 1
-fi
-
-if [ ! -L "$VOLUME_PATH" ]; then
-    echo "warning: $VOLUME_PATH is not a symlink"
 fi
 
 # Submits ProxyAdmin.upgrade(moatProxy, newImpl) from the ProxyAdmin owner.


### PR DESCRIPTION
Summary:
- Stop requiring repo-root volume to be a symlink in Moat upgrade shell scripts.
- Update the missing-volume hint to describe a normal local volume directory containing config.toml and config-contracts.toml.

Validation:
- rg -n "volume is not a symlink|ln -sfn|symlink" scripts/deterministic/shell -S
- sh -n scripts/deterministic/shell/deploy-moat-impl.sh && sh -n scripts/deterministic/shell/submit-moat-proxy-upgrade.sh && sh -n scripts/deterministic/shell/deploy-fee-vault-moat-adapter.sh && sh -n scripts/deterministic/shell/submit-fee-vault-rewire.sh && sh -n scripts/deterministic/shell/deploy-dogeos-messenger-impl.sh && sh -n scripts/deterministic/shell/submit-dogeos-messenger-proxy-upgrade.sh