### PR TITLE
chore: ignore build-time artifacts (solc blob, __pycache__, npm lockfile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,16 @@ artifacts
 artifacts-hardhat
 broadcast
 
+# solc compiler binary (downloaded at build time)
+soljson-*.js
+
+# Python bytecode (scripts/dogeos tooling)
+__pycache__/
+*.pyc
+
+# npm lockfile (this repo uses yarn)
+package-lock.json
+
 # logs
 *.log
 


### PR DESCRIPTION
## What
Add downloaded/generated build artifacts to `.gitignore` so they stop appearing as untracked noise in working trees:

- `soljson-*.js` — solc compiler binary fetched at build time (matches root and `src/`)
- `__pycache__/`, `*.pyc` — Python bytecode from `scripts/dogeos` tooling
- `package-lock.json` — this repo standardizes on yarn (`yarn.lock` is tracked)

## Why
All of these are regenerable and were never committed; this is purely additive ignore hygiene.

## Notes
- Verified the patterns match the intended paths and do **not** catch `yarn.lock` or source files.
- `.claude/` and `foundry.lock` intentionally left out (team / Foundry-convention call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)